### PR TITLE
[Addition] New Record Embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ﻿## Release Notes
 
 
+## [2.5.9]
+
+### Added
+
+- Checkpoints difference for records is now sent to the Discord Webhook and shown in the embed.
+
+## [2.5.8]
+
+### Fixed
+
+- Fixed handles being deleted twice.
+
 ## [2.5.7]
 
 ### Added

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -879,8 +879,8 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		field = new EmbedField("Map Tier", MapTier, true);
 		embed.AddField(field);
 
-		/* */
-		if(strlen(checkpoints) > 0 && bonusGroup == -1 && stage < 1)
+		/* Add checkpoints to an EmbedField - Limitations https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure */
+		if(strlen(checkpoints) > 0 && strlen(checkpoints) < 1050 && bonusGroup == -1 && stage < 1)
 		{
 			field = new EmbedField("Checkpoints", checkpoints, true);
 			embed.AddField(field);

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -7,7 +7,7 @@
 #include <mapchallenge>
 #pragma newdecls required
 #pragma semicolon 1
-#define DEBUG // Enable this line and compile again to enable DEBUG messages
+// #define DEBUG // Enable this line and compile again to enable DEBUG messages
 
 public Plugin myinfo =
 {
@@ -242,16 +242,16 @@ public Action CommandDiscordTest(int client, int args)
 
 	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending main record test message.");
 	surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", -1, testArray);
-	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending bonus record test message.");
-	// surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", 1, testArray);
-	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending stage record test message.");
-	// surftimer_OnNewWRCP(client, 0, "00:00:00", "-00:00:00", 3, 0.0);
-	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} bonus record test message.");
-	// surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", 1, testArray);
-	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} main record test message.");
-	// surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", -1, testArray);
-	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} stage record test message.");
-	// surftimer_OnNewWRCP(client, 5, "00:00:00", "-00:00:00", 3, 0.0);
+	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending bonus record test message.");
+	surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", 1, testArray);
+	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending stage record test message.");
+	surftimer_OnNewWRCP(client, 0, "00:00:00", "-00:00:00", 3, 0.0);
+	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} bonus record test message.");
+	surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", 1, testArray);
+	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} main record test message.");
+	surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", -1, testArray);
+	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} stage record test message.");
+	surftimer_OnNewWRCP(client, 5, "00:00:00", "-00:00:00", 3, 0.0);
 	
 	if (g_bIsChallengeEnabled)
 	{
@@ -279,9 +279,6 @@ public Action CommandDiscordTest(int client, int args)
 
 		mapchallenge_OnChallengeEnd(client, "surf_beginner", 0, 420, "Mon Jan 1 00:00:00 1969", "Thu Aug 23 14:55:02 2001", szTop5, 666);
 	}
-	
-	// delete testArray;
-	// PrintToServer("======== deleted testArray");
 	return Plugin_Handled;
 }
 
@@ -537,11 +534,11 @@ public void surftimer_OnNewRecord(int client, int style, char[] time, char[] tim
 			checkpoints.GetArray(i, temp, sizeof(temp));
 			if(i == 0)
 			{
-				Format(cpsFinalString, sizeof(cpsFinalString), "%i WR: %s | PB: %s | %s", temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
+				Format(cpsFinalString, sizeof(cpsFinalString), "%i. WR: %s | PB: %s | %s", temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
 			}
 			else
 			{
-				Format(cpsFinalString, sizeof(cpsFinalString), "%s\n%i WR: %s | PB: %s | %s", cpsFinalString, temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
+				Format(cpsFinalString, sizeof(cpsFinalString), "%s\n%i. WR: %s | PB: %s | %s", cpsFinalString, temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
 			}
 		}
 		ReplaceString(cpsFinalString, sizeof(cpsFinalString), "00:0", "");
@@ -553,7 +550,6 @@ public void surftimer_OnNewRecord(int client, int style, char[] time, char[] tim
 		GetProfilePictureURL(client, style, time, timeDif, bonusGroup, -1, cpsFinalString);
 	else
 		sendDiscordAnnouncement(client, style, time, timeDif, bonusGroup, -1, cpsFinalString);
-	delete checkpoints;
 }
 
 public void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime)
@@ -883,9 +879,8 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		field = new EmbedField("Map Tier", MapTier, true);
 		embed.AddField(field);
 
-		PrintToServer("===== checkpoints : %s", checkpoints);
 		/* */
-		if(strlen(checkpoints) > 0)
+		if(strlen(checkpoints) > 0 && bonusGroup == -1 && stage < 1)
 		{
 			field = new EmbedField("Checkpoints", checkpoints, true);
 			embed.AddField(field);
@@ -927,11 +922,6 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		}
 
 		hook.AddEmbed(embed);
-		char szDebugOutput2[10000];
-		hook.ToString(szDebugOutput2, sizeof szDebugOutput2);
-		hook.ToFile("discord.json", JSON_INDENT(4));
-		PrintToServer(szDebugOutput2);
-
 		hook.Execute(webhook, OnWebHookExecuted, client);
 		#if defined DEBUG
 			char szDebugOutput[10000];
@@ -1032,7 +1022,6 @@ stock void OnResponseReceived(HTTPResponse response, DataPack pack)
 	delete Response;
 	delete players;
 	delete player;
-	PrintToServer("==OnResponseReceived=== checkpoints : %s", checkpoints);
 	sendDiscordAnnouncement(client, style, szTime, szTimeDif, bonusGroup, stage, checkpoints);
 }
 
@@ -1067,32 +1056,27 @@ stock bool IsValidClient(int iClient, bool bNoBots = true)
 
 public void OnWebHookExecuted(HTTPResponse response, int client)
 {
-	PrintToServer("============ response.Status %d", response.Status);
 	#if defined DEBUG
 		PrintToServer("Processed client n°%d's webhook, status %d", client, response.Status);
-		if (response.Status != HTTPStatus_NoContent)
+		if (response.Status != HTTPStatus_OK)
 		{
 			PrintToServer("An error has occured while sending the webhook.");
 			JSONObject objects   = view_as<JSONObject>(response.Data);
 			char responseMsg[1000];
 			if (objects.GetString("message", responseMsg, sizeof(responseMsg)))
 			{
-				PrintToServer("Discord API reply message: %s", responseMsg);
-				int responseCode = objects.GetInt("code");
-				PrintToServer("Discord API reply code: %i", responseCode);
+				PrintToServer("-- Discord API reply message: %s", responseMsg);
+				if (StrContains(responseMsg, "rate limited") > -1)
+				{
+					float retry = objects.GetFloat("retry_after");
+					PrintToServer("-- You are being rate limited, please try again after %f", retry);
+				}
+				else
+				{
+					int responseCode = objects.GetInt("code");
+					PrintToServer("-- Discord API reply code: %i", responseCode);
+				}
 			}
-			
-			// char rspns[10000];
-			// JSONObjectKeys objectKeys = objects.Keys();
-			// while(objectKeys.ReadKey(responseMsg, sizeof(responseMsg)))
-			// {
-			// 	PrintToServer("Key: %s", responseMsg);
-			// 	objects.GetString(responseMsg, rspns, sizeof(rspns));
-			// 	PrintToServer("Key: %s | Value: %s", responseMsg, rspns);
-			// }
-
-			// PrintToServer("Response.Data = %s", response.Data);
-
 			delete objects;
 			return;
 		}

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -14,7 +14,7 @@ public Plugin myinfo =
 	name        = "SurfTimer-Discord",
 	author      = "Sarrus",
 	description = "A module for SurfTimer-Official to send Discord Notifications when a new record is set.",
-	version     = "2.5.7",
+	version     = "2.5.9",
 	url         = "https://github.com/Sarrus1/SurfTimer-discord"
 };
 

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -880,7 +880,13 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		embed.AddField(field);
 
 		/* Add checkpoints to an EmbedField - Limitations https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure */
-		if(strlen(checkpoints) > 0 && strlen(checkpoints) < 1050 && bonusGroup == -1 && stage < 1)
+		char tempCps[1000];
+		StrCat(tempCps, sizeof(tempCps), checkpoints);
+		ReplaceString(tempCps, sizeof(tempCps), "\n", "");
+		ReplaceString(tempCps, sizeof(tempCps), "```fix", "");
+		ReplaceString(tempCps, sizeof(tempCps), "```", "");
+		ReplaceString(tempCps, sizeof(tempCps), " ", "");
+		if(strlen(checkpoints) > 0 && strlen(tempCps) < 1024 && bonusGroup == -1 && stage < 1)
 		{
 			field = new EmbedField("Checkpoints", checkpoints, true);
 			embed.AddField(field);

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -7,7 +7,7 @@
 #include <mapchallenge>
 #pragma newdecls required
 #pragma semicolon 1
-// #define DEBUG // Enable this line and compile again to enable DEBUG messages
+#define DEBUG // Enable this line and compile again to enable DEBUG messages
 
 public Plugin myinfo =
 {
@@ -71,6 +71,15 @@ enum struct TOP5_entry{
 	char szPlayerName[MAX_NAME_LENGTH];
 	char szRuntimeFormatted[32];
 	char szRuntimeDifference[32];
+}
+
+enum struct RunCheckpoints
+{
+	int cpNumber;
+	int style;
+	char runtime[32];
+	char wrDifference[32];
+	char pbDifference[32];
 }
 
 WaitingFor g_iWaitingFor[MAXPLAYERS + 1];
@@ -206,18 +215,43 @@ public Action CommandDiscordTest(int client, int args)
 		CReplyToCommand(0, "This command is only available in game.");
 		return Plugin_Handled;
 	}
+	ArrayList testArray;
+	testArray = new ArrayList(sizeof(RunCheckpoints));
+
+	RunCheckpoints cpEnum;
+	cpEnum.cpNumber = 1;
+	cpEnum.runtime = "01:00.00";
+	cpEnum.pbDifference = "-00:00.00";
+	cpEnum.wrDifference = "-00:00.00";
+	cpEnum.style = 0;
+	testArray.PushArray(cpEnum, sizeof(RunCheckpoints));
+
+	cpEnum.cpNumber = 2;
+	cpEnum.runtime = "02:00.00";
+	cpEnum.pbDifference = "-00:00.00";
+	cpEnum.wrDifference = "-00:00.00";
+	cpEnum.style = 0;
+	testArray.PushArray(cpEnum, sizeof(RunCheckpoints));
+
+	cpEnum.cpNumber = 3;
+	cpEnum.runtime = "03:00.00";
+	cpEnum.pbDifference = "-00:00.00";
+	cpEnum.wrDifference = "-00:00.00";
+	cpEnum.style = 0;
+	testArray.PushArray(cpEnum, sizeof(RunCheckpoints));
+
 	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending main record test message.");
-	surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", -1);
-	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending bonus record test message.");
-	surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", 1);
-	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending stage record test message.");
-	surftimer_OnNewWRCP(client, 0, "00:00:00", "-00:00:00", 3, 0.0);
-	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} bonus record test message.");
-	surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", 1);
-	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} main record test message.");
-	surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", -1);
-	CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} stage record test message.");
-	surftimer_OnNewWRCP(client, 5, "00:00:00", "-00:00:00", 3, 0.0);
+	surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", -1, testArray);
+	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending bonus record test message.");
+	// surftimer_OnNewRecord(client, 0, "00:00:00", "-00:00:00", 1, testArray);
+	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending stage record test message.");
+	// surftimer_OnNewWRCP(client, 0, "00:00:00", "-00:00:00", 3, 0.0);
+	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} bonus record test message.");
+	// surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", 1, testArray);
+	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} main record test message.");
+	// surftimer_OnNewRecord(client, 5, "00:00:00", "-00:00:00", -1, testArray);
+	// CReplyToCommand(client, "{blue}[SurfTimer-Discord] {green}Sending {red}styled{green} stage record test message.");
+	// surftimer_OnNewWRCP(client, 5, "00:00:00", "-00:00:00", 3, 0.0);
 	
 	if (g_bIsChallengeEnabled)
 	{
@@ -246,6 +280,8 @@ public Action CommandDiscordTest(int client, int args)
 		mapchallenge_OnChallengeEnd(client, "surf_beginner", 0, 420, "Mon Jan 1 00:00:00 1969", "Thu Aug 23 14:55:02 2001", szTop5, 666);
 	}
 	
+	// delete testArray;
+	// PrintToServer("======== deleted testArray");
 	return Plugin_Handled;
 }
 
@@ -490,20 +526,42 @@ public void OnMapStart()
 	GetConVarString(g_cvSteamWebAPIKey, g_szApiKey, sizeof g_szApiKey);
 }
 
-public void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup)
+public void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup, ArrayList checkpoints)
 {
+	char cpsFinalString[300];
+	if(checkpoints != null && checkpoints.Length > 0)
+	{
+		RunCheckpoints temp;
+		for(int i = 0; i <= checkpoints.Length-1; i++)
+		{
+			checkpoints.GetArray(i, temp, sizeof(temp));
+			if(i == 0)
+			{
+				Format(cpsFinalString, sizeof(cpsFinalString), "%i WR: %s | PB: %s | %s", temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
+			}
+			else
+			{
+				Format(cpsFinalString, sizeof(cpsFinalString), "%s\n%i WR: %s | PB: %s | %s", cpsFinalString, temp.cpNumber, temp.wrDifference, temp.pbDifference, temp.runtime);
+			}
+		}
+		ReplaceString(cpsFinalString, sizeof(cpsFinalString), "00:0", "");
+		ReplaceString(cpsFinalString, sizeof(cpsFinalString), "00:", "");
+		Format(cpsFinalString, sizeof(cpsFinalString), "```fix\n%s\n```", cpsFinalString);
+	}
+	
 	if (strncmp(g_szApiKey, "", 1) != 0)
-		GetProfilePictureURL(client, style, time, timeDif, bonusGroup, -1);
+		GetProfilePictureURL(client, style, time, timeDif, bonusGroup, -1, cpsFinalString);
 	else
-		sendDiscordAnnouncement(client, style, time, timeDif, bonusGroup, -1);
+		sendDiscordAnnouncement(client, style, time, timeDif, bonusGroup, -1, cpsFinalString);
+	delete checkpoints;
 }
 
 public void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime)
 {
 	if (strncmp(g_szApiKey, "", 1) != 0)
-		GetProfilePictureURL(client, style, time, timeDif, -1, stage);
+		GetProfilePictureURL(client, style, time, timeDif, -1, stage, "");
 	else
-		sendDiscordAnnouncement(client, style, time, timeDif, -1, stage);
+		sendDiscordAnnouncement(client, style, time, timeDif, -1, stage, "");
 }
 
 public void mapchallenge_OnNewChallenge(int client, char szMapName[32], int style, int points, char szInitial_Timestamp[32], char szFinal_Timestamp[32]){
@@ -727,7 +785,7 @@ public void mapchallenge_OnChallengeEnd(int client, char szMapName[32], int styl
 	delete hook;
 }
 
-stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] szTimeDif, int bonusGroup, int stage)
+stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] szTimeDif, int bonusGroup, int stage, char[] checkpoints)
 {
 	// Get the WebHook
 	char webhook[1024], webhookName[1024];
@@ -825,6 +883,14 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		field = new EmbedField("Map Tier", MapTier, true);
 		embed.AddField(field);
 
+		PrintToServer("===== checkpoints : %s", checkpoints);
+		/* */
+		if(strlen(checkpoints) > 0)
+		{
+			field = new EmbedField("Checkpoints", checkpoints, true);
+			embed.AddField(field);
+		}
+
 		char szUrlMain[1024];
 		GetConVarString(g_cvMainUrlRoot, szUrlMain, 1024);
 		StrCat(szUrlMain, sizeof szUrlMain, g_szCurrentMap);
@@ -861,6 +927,11 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		}
 
 		hook.AddEmbed(embed);
+		char szDebugOutput2[10000];
+		hook.ToString(szDebugOutput2, sizeof szDebugOutput2);
+		hook.ToFile("discord.json", JSON_INDENT(4));
+		PrintToServer(szDebugOutput2);
+
 		hook.Execute(webhook, OnWebHookExecuted, client);
 		#if defined DEBUG
 			char szDebugOutput[10000];
@@ -905,7 +976,7 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 	}
 }
 
-stock void GetProfilePictureURL(int client, int style, char[] time, char[] timeDif, int bonusGroup, int stage)
+stock void GetProfilePictureURL(int client, int style, char[] time, char[] timeDif, int bonusGroup, int stage, char[] checkpoints)
 {
 	DataPack pack = new DataPack();
 	pack.WriteCell(client);
@@ -914,6 +985,7 @@ stock void GetProfilePictureURL(int client, int style, char[] time, char[] timeD
 	pack.WriteString(timeDif);
 	pack.WriteCell(bonusGroup);
 	pack.WriteCell(stage);
+	pack.WriteString(checkpoints);
 	pack.Reset();
 
 	char szRequestBuffer[1024], szSteamID[64];
@@ -938,6 +1010,8 @@ stock void OnResponseReceived(HTTPResponse response, DataPack pack)
 	ReadPackString(pack, szTimeDif, sizeof szTimeDif);
 	int bonusGroup = pack.ReadCell();
 	int stage      = pack.ReadCell();
+	char checkpoints[300];
+	ReadPackString(pack, checkpoints, sizeof(checkpoints));
 
 	if (response.Status != HTTPStatus_OK)
 		return;
@@ -958,7 +1032,8 @@ stock void OnResponseReceived(HTTPResponse response, DataPack pack)
 	delete Response;
 	delete players;
 	delete player;
-	sendDiscordAnnouncement(client, style, szTime, szTimeDif, bonusGroup, stage);
+	PrintToServer("==OnResponseReceived=== checkpoints : %s", checkpoints);
+	sendDiscordAnnouncement(client, style, szTime, szTimeDif, bonusGroup, stage, checkpoints);
 }
 
 stock void RemoveWorkshop(char[] szMapName, int len)
@@ -992,6 +1067,7 @@ stock bool IsValidClient(int iClient, bool bNoBots = true)
 
 public void OnWebHookExecuted(HTTPResponse response, int client)
 {
+	PrintToServer("============ response.Status %d", response.Status);
 	#if defined DEBUG
 		PrintToServer("Processed client n°%d's webhook, status %d", client, response.Status);
 		if (response.Status != HTTPStatus_NoContent)
@@ -1006,6 +1082,17 @@ public void OnWebHookExecuted(HTTPResponse response, int client)
 				PrintToServer("Discord API reply code: %i", responseCode);
 			}
 			
+			// char rspns[10000];
+			// JSONObjectKeys objectKeys = objects.Keys();
+			// while(objectKeys.ReadKey(responseMsg, sizeof(responseMsg)))
+			// {
+			// 	PrintToServer("Key: %s", responseMsg);
+			// 	objects.GetString(responseMsg, rspns, sizeof(rspns));
+			// 	PrintToServer("Key: %s | Value: %s", responseMsg, rspns);
+			// }
+
+			// PrintToServer("Response.Data = %s", response.Data);
+
 			delete objects;
 			return;
 		}

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -525,7 +525,7 @@ public void OnMapStart()
 
 public void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup, ArrayList checkpoints)
 {
-	char cpsFinalString[300];
+	char cpsFinalString[1100];
 	if(checkpoints != null && checkpoints.Length > 0)
 	{
 		RunCheckpoints temp;
@@ -1006,7 +1006,7 @@ stock void OnResponseReceived(HTTPResponse response, DataPack pack)
 	ReadPackString(pack, szTimeDif, sizeof szTimeDif);
 	int bonusGroup = pack.ReadCell();
 	int stage      = pack.ReadCell();
-	char checkpoints[300];
+	char checkpoints[1100];
 	ReadPackString(pack, checkpoints, sizeof(checkpoints));
 
 	if (response.Status != HTTPStatus_OK)

--- a/scripting/SurfTimer-discord.sp
+++ b/scripting/SurfTimer-discord.sp
@@ -880,7 +880,7 @@ stock void sendDiscordAnnouncement(int client, int style, char[] szTime, char[] 
 		embed.AddField(field);
 
 		/* Add checkpoints to an EmbedField - Limitations https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure */
-		char tempCps[1000];
+		char tempCps[1100];
 		StrCat(tempCps, sizeof(tempCps), checkpoints);
 		ReplaceString(tempCps, sizeof(tempCps), "\n", "");
 		ReplaceString(tempCps, sizeof(tempCps), "```fix", "");

--- a/scripting/include/discordWebhookAPI.inc
+++ b/scripting/include/discordWebhookAPI.inc
@@ -1,1014 +1,1015 @@
-﻿#include <ripext>
+#if defined _discordWebhookAPI_included_
+  #endinput
+#endif
+#define _discordWebhookAPI_included_
+
+#include <ripext>
 
 methodmap EmbedFooter < JSONObject
 {
-	/**
-	 * Constructor for the EmbedFooter methodmap.
-	 * 
-	 * @param text    Text of the footer.
-	 * @return        Returns the EmbedFooter.
-	 */
-	public EmbedFooter(const char[] text="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("text", text);
-		return view_as<EmbedFooter>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedFooter methodmap.
+   * 
+   * @param text    Text of the footer.
+   * @return        Returns the EmbedFooter.
+   */
+  public EmbedFooter(const char[] text="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("text", text);
+    return view_as<EmbedFooter>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the text of the footer.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetText(char[] buffer, int maxlength)
-	{
-		return this.GetString("text", buffer, maxlength);
-	}
+  /**
+   * Retrieve the text of the footer.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetText(char[] buffer, int maxlength)
+  {
+    return this.GetString("text", buffer, maxlength);
+  }
 
-	/**
-	 * Set the text of the footer.
-	 * 
-	 * @param text    Text of the footer.
-	 * @return        True on success. False otherwise.
-	 */
-	public bool SetText(const char[] text)
-	{
-		return this.SetString("text", text);
-	}
+  /**
+   * Set the text of the footer.
+   * 
+   * @param text    Text of the footer.
+   * @return        True on success. False otherwise.
+   */
+  public bool SetText(const char[] text)
+  {
+    return this.SetString("text", text);
+  }
 
-	/**
-	 * Retrieve the url of the footer icon.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetIconURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("icon_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the url of the footer icon.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetIconURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("icon_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the url of the footer icon.
-	 * Note : this only supports http(s).
-	 * 
-	 * @param icon_url    IconURL of the footer.
-	 * @return            True on success. False otherwise.
-	 */
-	public bool SetIconURL(const char[] icon_url)
-	{
-		return this.SetString("icon_url", icon_url);
-	}
+  /**
+   * Set the url of the footer icon.
+   * Note : this only supports http(s).
+   * 
+   * @param icon_url    IconURL of the footer.
+   * @return            True on success. False otherwise.
+   */
+  public bool SetIconURL(const char[] icon_url)
+  {
+    return this.SetString("icon_url", icon_url);
+  }
 
-	/**
-	 * Retrieve the proxy_icon_url of the footer.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetProxyIconURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("proxy_icon_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the proxy_icon_url of the footer.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetProxyIconURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("proxy_icon_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set a proxied url of the footer icon.
-	 * 
-	 * @param proxy_icon_url    IconURL of the footer.
-	 * @return                  True on success. False otherwise.
-	 */
-	public bool SetProxyIconURL(const char[] proxy_icon_url)
-	{
-		return this.SetString("proxy_icon_url", proxy_icon_url);
-	}
+  /**
+   * Set a proxied url of the footer icon.
+   * 
+   * @param proxy_icon_url    IconURL of the footer.
+   * @return                  True on success. False otherwise.
+   */
+  public bool SetProxyIconURL(const char[] proxy_icon_url)
+  {
+    return this.SetString("proxy_icon_url", proxy_icon_url);
+  }
 }
 
 
 methodmap EmbedImage < JSONObject
 {
-	/**
-	 * Constructor for the EmbedImage methodmap.
-	 * 
-	 * @param url    URL of the image.
-	 * @return       Returns the EmbedImage.
-	 */
-	public EmbedImage(const char[] url="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("url", url);
-		return view_as<EmbedImage>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedImage methodmap.
+   * 
+   * @param url    URL of the image.
+   * @return       Returns the EmbedImage.
+   */
+  public EmbedImage(const char[] url="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("url", url);
+    return view_as<EmbedImage>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the source url of the media.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the source url of the media.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the source url of the media.
-	 * Note : this only supports http(s).
-	 * 
-	 * @param url    URL of the media.
-	 * @return       True on success. False otherwise.
-	 */
-	public bool SetURL(const char[] url)
-	{
-		return this.SetString("url", url);
-	}
+  /**
+   * Set the source url of the media.
+   * Note : this only supports http(s).
+   * 
+   * @param url    URL of the media.
+   * @return       True on success. False otherwise.
+   */
+  public bool SetURL(const char[] url)
+  {
+    return this.SetString("url", url);
+  }
 
-	/**
-	 * Retrieve the proxied URL of the media.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetProxyURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("proxy_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the proxied URL of the media.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetProxyURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("proxy_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set a proxied URL of the media.
-	 * 
-	 * @param proxy_url    Proxy URL of the media.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool SetProxyURL(const char[] proxy_url)
-	{
-		return this.SetString("proxy_url", proxy_url);
-	}
+  /**
+   * Set a proxied URL of the media.
+   * 
+   * @param proxy_url    Proxy URL of the media.
+   * @return             True on success. False otherwise.
+   */
+  public bool SetProxyURL(const char[] proxy_url)
+  {
+    return this.SetString("proxy_url", proxy_url);
+  }
 
-	/**
-	 * Retrieve the height of the media.
-	 * 
-	 * @return    Int value of the media.
-	 */
-	public int GetHeight()
-	{
-		return this.GetInt("height");
-	}
+  /**
+   * Retrieve the height of the media.
+   * 
+   * @return    Int value of the media.
+   */
+  public int GetHeight()
+  {
+    return this.GetInt("height");
+  }
 
-	/**
-	 * Set the height of the media.
-	 * 
-	 * @param height    Height of the media.
-	 * @return          True on success. False otherwise.
-	 */
-	public bool SetHeight(int height)
-	{
-		return this.SetInt("height", height);
-	}
+  /**
+   * Set the height of the media.
+   * 
+   * @param height    Height of the media.
+   * @return          True on success. False otherwise.
+   */
+  public bool SetHeight(int height)
+  {
+    return this.SetInt("height", height);
+  }
 
-	/**
-	 * Retrieve the width of the media.
-	 * 
-	 * @return    Int value of the media.
-	 */
-	public int GetWidth()
-	{
-		return this.GetInt("width");
-	}
+  /**
+   * Retrieve the width of the media.
+   * 
+   * @return    Int value of the media.
+   */
+  public int GetWidth()
+  {
+    return this.GetInt("width");
+  }
 
-	/**
-	 * Set the width of the media.
-	 * 
-	 * @param width    Width of the media.
-	 * @return         True on success. False otherwise.
-	 */
-	public bool SetWidth(int width)
-	{
-		return this.SetInt("width", width);
-	}
+  /**
+   * Set the width of the media.
+   * 
+   * @param width    Width of the media.
+   * @return         True on success. False otherwise.
+   */
+  public bool SetWidth(int width)
+  {
+    return this.SetInt("width", width);
+  }
 }
 
 
 methodmap EmbedThumbnail < EmbedImage
 {
-	/**
-	 * Constructor for the EmbedThumbnail methodmap.
-	 * 
-	 * @param url    URL of the thumbnail.
-	 * @return       Returns the EmbedThumbnail.
-	 */
-	public EmbedThumbnail(const char[] url="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("url", url);
-		return view_as<EmbedThumbnail>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedThumbnail methodmap.
+   * 
+   * @param url    URL of the thumbnail.
+   * @return       Returns the EmbedThumbnail.
+   */
+  public EmbedThumbnail(const char[] url="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("url", url);
+    return view_as<EmbedThumbnail>(jsonObject);
+  }
 }
 
 
 methodmap EmbedVideo < EmbedImage
 {
-	/**
-	 * Constructor for the EmbedVideo methodmap.
-	 * 
-	 * @param url    URL of the video.
-	 * @return       Returns the EmbedVideo.
-	 */
-	public EmbedVideo(const char[] url="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("url", url);
-		return view_as<EmbedVideo>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedVideo methodmap.
+   * 
+   * @param url    URL of the video.
+   * @return       Returns the EmbedVideo.
+   */
+  public EmbedVideo(const char[] url="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("url", url);
+    return view_as<EmbedVideo>(jsonObject);
+  }
 }
 
 
 methodmap EmbedProvider < JSONObject
 {
-	/**
-	 * Constructor for the EmbedProvider methodmap.
-	 * 
-	 * @param name    Name of the provider.
-	 * @return        Returns the EmbedProvider.
-	 */
-	public EmbedProvider(const char[] name="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("name", name);
-		return view_as<EmbedProvider>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedProvider methodmap.
+   * 
+   * @param name    Name of the provider.
+   * @return        Returns the EmbedProvider.
+   */
+  public EmbedProvider(const char[] name="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("name", name);
+    return view_as<EmbedProvider>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the name of the provider.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetName(char[] buffer, int maxlength)
-	{
-		return this.GetString("name", buffer, maxlength);
-	}
+  /**
+   * Retrieve the name of the provider.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetName(char[] buffer, int maxlength)
+  {
+    return this.GetString("name", buffer, maxlength);
+  }
 
-	/**
-	 * Set the name of the provider.
-	 * 
-	 * @param name    Name of the provider.
-	 * @return        True on success. False otherwise.
-	 */
-	public bool SetName(const char[] name)
-	{
-		return this.SetString("name", name);
-	}
+  /**
+   * Set the name of the provider.
+   * 
+   * @param name    Name of the provider.
+   * @return        True on success. False otherwise.
+   */
+  public bool SetName(const char[] name)
+  {
+    return this.SetString("name", name);
+  }
 
-		/**
-	 * Retrieve the source url of the provider.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("url", buffer, maxlength);
-	}
+    /**
+   * Retrieve the source url of the provider.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the source url of the provider.
-	 * 
-	 * @param url    URL of the provider.
-	 * @return       True on success. False otherwise.
-	 */
-	public bool SetURL(const char[] url)
-	{
-		return this.SetString("url", url);
-	}
+  /**
+   * Set the source url of the provider.
+   * 
+   * @param url    URL of the provider.
+   * @return       True on success. False otherwise.
+   */
+  public bool SetURL(const char[] url)
+  {
+    return this.SetString("url", url);
+  }
 }
 
 
 methodmap EmbedAuthor < JSONObject
 {
-	/**
-	 * Constructor for the EmbedAuthor methodmap.
-	 * 
-	 * @param name    Name of the author.
-	 * @return        Returns the EmbedAuthor.
-	 */
-	public EmbedAuthor(const char[] name="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("name", name);
-		return view_as<EmbedAuthor>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedAuthor methodmap.
+   * 
+   * @param name    Name of the author.
+   * @return        Returns the EmbedAuthor.
+   */
+  public EmbedAuthor(const char[] name="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("name", name);
+    return view_as<EmbedAuthor>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the name of the author.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetName(char[] buffer, int maxlength)
-	{
-		return this.GetString("name", buffer, maxlength);
-	}
+  /**
+   * Retrieve the name of the author.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetName(char[] buffer, int maxlength)
+  {
+    return this.GetString("name", buffer, maxlength);
+  }
 
-	/**
-	 * Set the name of the author.
-	 * 
-	 * @param name    Name of the author.
-	 * @return        True on success. False otherwise.
-	 */
-	public bool SetName(const char[] name)
-	{
-		return this.SetString("name", name);
-	}
+  /**
+   * Set the name of the author.
+   * 
+   * @param name    Name of the author.
+   * @return        True on success. False otherwise.
+   */
+  public bool SetName(const char[] name)
+  {
+    return this.SetString("name", name);
+  }
 
-	/**
-	 * Retrieve the url of the author.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the url of the author.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the url of the author.
-	 * 
-	 * @param url    URL of the author.
-	 * @return       True on success. False otherwise.
-	 */
-	public bool SetURL(const char[] url)
-	{
-		return this.SetString("url", url);
-	}
+  /**
+   * Set the url of the author.
+   * 
+   * @param url    URL of the author.
+   * @return       True on success. False otherwise.
+   */
+  public bool SetURL(const char[] url)
+  {
+    return this.SetString("url", url);
+  }
 
-	/**
-	 * Retrieve the icon_url of the author.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetIconURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("icon_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the icon_url of the author.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetIconURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("icon_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the icon_url of the author.
-	 * Note : this only supports http(s).
-	 * 
-	 * @param icon_url    IconURL of the author.
-	 * @return            True on success. False otherwise.
-	 */
-	public bool SetIconURL(const char[] icon_url)
-	{
-		return this.SetString("icon_url", icon_url);
-	}
+  /**
+   * Set the icon_url of the author.
+   * Note : this only supports http(s).
+   * 
+   * @param icon_url    IconURL of the author.
+   * @return            True on success. False otherwise.
+   */
+  public bool SetIconURL(const char[] icon_url)
+  {
+    return this.SetString("icon_url", icon_url);
+  }
 
-	/**
-	 * Retrieve the proxy_icon_url of the author.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetProxyIconURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("proxy_icon_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the proxy_icon_url of the author.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetProxyIconURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("proxy_icon_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set a proxied url of the author.
-	 * 
-	 * @param proxy_icon_url    IconURL of the author.
-	 * @return                  True on success. False otherwise.
-	 */
-	public bool SetProxyIconURL(const char[] proxy_icon_url)
-	{
-		return this.SetString("proxy_icon_url", proxy_icon_url);
-	}
+  /**
+   * Set a proxied url of the author.
+   * 
+   * @param proxy_icon_url    IconURL of the author.
+   * @return                  True on success. False otherwise.
+   */
+  public bool SetProxyIconURL(const char[] proxy_icon_url)
+  {
+    return this.SetString("proxy_icon_url", proxy_icon_url);
+  }
 }
 
 
 methodmap EmbedField < JSONObject
 {
-	/**
-	 * Constructor for the EmbedField methodmap.
-	 * 
-	 * @param name      Name of the field.
-	 * @param value     Value of the field.
-	 * @param inline    Bool value of the inline @parameter.
-	 * @return          Returns the EmbedField.
-	 */
-	public EmbedField(const char[] name="", const char[] value="", bool inline=true) 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("name", name);
-		jsonObject.SetString("value", value);
-		jsonObject.SetBool("inline", inline);
-		return view_as<EmbedField>(jsonObject);
-	}
+  /**
+   * Constructor for the EmbedField methodmap.
+   * 
+   * @param name      Name of the field.
+   * @param value     Value of the field.
+   * @param inline    Bool value of the inline @parameter.
+   * @return          Returns the EmbedField.
+   */
+  public EmbedField(const char[] name="", const char[] value="", bool inline=true) 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("name", name);
+    jsonObject.SetString("value", value);
+    jsonObject.SetBool("inline", inline);
+    return view_as<EmbedField>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the name of the field.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetName(char[] buffer, int maxlength)
-	{
-		return this.GetString("name", buffer, maxlength);
-	}
+  /**
+   * Retrieve the name of the field.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetName(char[] buffer, int maxlength)
+  {
+    return this.GetString("name", buffer, maxlength);
+  }
 
-	/**
-	 * Set the name of the field.
-	 * 
-	 * @param name    Name of the field.
-	 * @return        True on success. False otherwise.
-	 */
-	public bool SetName(const char[] name)
-	{
-		return this.SetString("name", name);
-	}
+  /**
+   * Set the name of the field.
+   * 
+   * @param name    Name of the field.
+   * @return        True on success. False otherwise.
+   */
+  public bool SetName(const char[] name)
+  {
+    return this.SetString("name", name);
+  }
 
-	/**
-	 * Retrieve the value of the field.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetValue(char[] buffer, int maxlength)
-	{
-		return this.GetString("value", buffer, maxlength);
-	}
+  /**
+   * Retrieve the value of the field.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetValue(char[] buffer, int maxlength)
+  {
+    return this.GetString("value", buffer, maxlength);
+  }
 
-	/**
-	 * Set the value of the field.
-	 * 
-	 * @param value    Value of the field.
-	 * @return         True on success. False otherwise.
-	 */
-	public bool SetValue(const char[] value)
-	{
-		return this.SetString("value", value);
-	}
+  /**
+   * Set the value of the field.
+   * 
+   * @param value    Value of the field.
+   * @return         True on success. False otherwise.
+   */
+  public bool SetValue(const char[] value)
+  {
+    return this.SetString("value", value);
+  }
 
-	/**
-	 * Retrieve the inline @parameter of the field.
-	 * 
-	 * @return    The bool value of the inline @parameter.
-	 */
-	public bool GetInline()
-	{
-		return this.GetBool("inline");
-	}
+  /**
+   * Retrieve the inline @parameter of the field.
+   * 
+   * @return    The bool value of the inline @parameter.
+   */
+  public bool GetInline()
+  {
+    return this.GetBool("inline");
+  }
 
-	/**
-	 * Set whether or not this field should display inline.
-	 * 
-	 * @param inline    Bool value of the inline @parameter.
-	 * @return          True on success. False otherwise.
-	 */
-	public bool SetInline(bool inline)
-	{
-		return this.SetBool("inline", inline);
-	}
+  /**
+   * Set whether or not this field should display inline.
+   * 
+   * @param inline    Bool value of the inline @parameter.
+   * @return          True on success. False otherwise.
+   */
+  public bool SetInline(bool inline)
+  {
+    return this.SetBool("inline", inline);
+  }
 }
 
 methodmap Embed < JSONObject
 {
-	/**
-	 * Constructor for the Embed methodmap.
-	 * 
-	 * @param title          Title of the embed.
-	 * @param description    Description of the embed.
-	 * @return               Returns the Embed.
-	 */
-	public Embed(const char[] title="", const char[] description="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetInt("color", 0);
-		jsonObject.SetString("title", title);
-		jsonObject.SetString("description", description);
-		return view_as<Embed>(jsonObject);
-	}
+  /**
+   * Constructor for the Embed methodmap.
+   * 
+   * @param title          Title of the embed.
+   * @param description    Description of the embed.
+   * @return               Returns the Embed.
+   */
+  public Embed(const char[] title="", const char[] description="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetInt("color", 0);
+    jsonObject.SetString("title", title);
+    jsonObject.SetString("description", description);
+    return view_as<Embed>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the title of the embed.
-	 * 
-	 * @param szBuffer       String buffer to store value.
-	 * @param iBufferSize    Maximum length of the string buffer.
-	 * @return               True on success. False otherwise.
-	 */
-	public bool GetTitle(char[] buffer, int maxlength)
-	{
-		return this.GetString("title", buffer, maxlength);
-	}
+  /**
+   * Retrieve the title of the embed.
+   * 
+   * @param szBuffer       String buffer to store value.
+   * @param iBufferSize    Maximum length of the string buffer.
+   * @return               True on success. False otherwise.
+   */
+  public bool GetTitle(char[] buffer, int maxlength)
+  {
+    return this.GetString("title", buffer, maxlength);
+  }
 
-	/**
-	 * Set the title of the embed.
-	 * 
-	 * @param title    Title of the embed.
-	 * @return         True on success. False otherwise.
-	 */
-	public bool SetTitle(const char[] title)
-	{
-		return this.SetString("title", title);
-	}
+  /**
+   * Set the title of the embed.
+   * 
+   * @param title    Title of the embed.
+   * @return         True on success. False otherwise.
+   */
+  public bool SetTitle(const char[] title)
+  {
+    return this.SetString("title", title);
+  }
 
-	/**
-	 * Retrieve the description of the embed.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetDescription(char[] buffer, int maxlength)
-	{
-		return this.GetString("description", buffer, maxlength);
-	}
+  /**
+   * Retrieve the description of the embed.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetDescription(char[] buffer, int maxlength)
+  {
+    return this.GetString("description", buffer, maxlength);
+  }
 
-	/**
-	 * Set the description of the embed.
-	 * 
-	 * @param description    Description of the embed.
-	 * @return               True on success. False otherwise.
-	 */
-	public bool SetDescription(const char[] description)
-	{
-		return this.SetString("description", description);
-	}
+  /**
+   * Set the description of the embed.
+   * 
+   * @param description    Description of the embed.
+   * @return               True on success. False otherwise.
+   */
+  public bool SetDescription(const char[] description)
+  {
+    return this.SetString("description", description);
+  }
 
-	/**
-	 * Retrieve the URL of the embed.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the URL of the embed.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the URL of the embed.
-	 * 
-	 * @param url    URL of the embed.
-	 * @return       True on success. False otherwise.
-	 */
-	public bool SetURL(const char[] url)
-	{
-		return this.SetString("url", url);
-	}
+  /**
+   * Set the URL of the embed.
+   * 
+   * @param url    URL of the embed.
+   * @return       True on success. False otherwise.
+   */
+  public bool SetURL(const char[] url)
+  {
+    return this.SetString("url", url);
+  }
 
-	/**
-	 * Retrieve the timestamp of the embed.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetTimeStamp(char[] buffer, int maxlength)
-	{
-		return this.GetString("timestamp", buffer, maxlength);
-	}
+  /**
+   * Retrieve the timestamp of the embed.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetTimeStamp(char[] buffer, int maxlength)
+  {
+    return this.GetString("timestamp", buffer, maxlength);
+  }
 
-	/**
-	 * Set the timestamp of the embed.
-	 * Note that the webhook will error out if the timestamp is not ISO 8601 complient.
-	 * Example: 1977-04-22T06:00:00Z
-	 * Use FormatTime to format it properly, see https://github.com/Sarrus1/discordWebhookAPI/blob/master/example.sp for an example.
-	 * 
-	 * @param timestamp    Timestamp of the embed.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool SetTimeStamp(const char[] timestamp)
-	{
-		return this.SetString("timestamp", timestamp);
-	}
+  /**
+   * Set the timestamp of the embed.
+   * Note that the webhook will error out if the timestamp is not ISO 8601 complient.
+   * Example: 1977-04-22T06:00:00Z
+   * Use FormatTime to format it properly, see https://github.com/Sarrus1/discordWebhookAPI/blob/master/example.sp for an example.
+   * 
+   * @param timestamp    Timestamp of the embed.
+   * @return             True on success. False otherwise.
+   */
+  public bool SetTimeStamp(const char[] timestamp)
+  {
+    return this.SetString("timestamp", timestamp);
+  }
 
-	/**
-	 * Set the timestamp of the embed to now.
-	 * 
-	 * @return    True on success. False otherwise.
-	 */
-	public bool SetTimeStampNow()
-	{
-		char timeNow[256];
-		FormatTime(timeNow, sizeof timeNow, "%FT\%T.000%z", GetTime());
-		return this.SetString("timestamp", timeNow);
-	}
+  /**
+   * Set the timestamp of the embed to now.
+   * 
+   * @return    True on success. False otherwise.
+   */
+  public bool SetTimeStampNow()
+  {
+    char timeNow[256];
+    FormatTime(timeNow, sizeof timeNow, "%FT\%T.000%z", GetTime());
+    return this.SetString("timestamp", timeNow);
+  }
 
-	/**
-	 * Retrieve the timestamp of the embed.
-	 * 
-	 * @return    Int value of the color.
-	 */
-	public int GetColor()
-	{
-		return this.GetInt("color");
-	}
+  /**
+   * Retrieve the timestamp of the embed.
+   * 
+   * @return    Int value of the color.
+   */
+  public int GetColor()
+  {
+    return this.GetInt("color");
+  }
 
-	/**
-	 * Set the color of the embed.
-	 * 
-	 * @param color    Color code of the embed.
-	 * @return         True on success. False otherwise.
-	 */
-	public bool SetColor(int color)
-	{
-		return this.SetInt("color", color);
-	}
+  /**
+   * Set the color of the embed.
+   * 
+   * @param color    Color code of the embed.
+   * @return         True on success. False otherwise.
+   */
+  public bool SetColor(int color)
+  {
+    return this.SetInt("color", color);
+  }
 
-	/**
-	 * Retrieve the footer of the embed.
-	 * 
-	 * @return    Footer of the embed.
-	 */
-	public EmbedFooter GetFooter()
-	{
-		return view_as<EmbedFooter>(this.Get("footer"));
-	}
+  /**
+   * Retrieve the footer of the embed.
+   * 
+   * @return    Footer of the embed.
+   */
+  public EmbedFooter GetFooter()
+  {
+    return view_as<EmbedFooter>(this.Get("footer"));
+  }
 
-	/**
-	 * Set the footer of the embed.
-	 * 
-	 * @param footer    Footer of the embed.
-	 * @return          True on success. False otherwise.
-	 */
-	public bool SetFooter(EmbedFooter footer)
-	{
-		return this.Set("footer", view_as<JSON>(footer));
-	}
+  /**
+   * Set the footer of the embed.
+   * 
+   * @param footer    Footer of the embed.
+   * @return          True on success. False otherwise.
+   */
+  public bool SetFooter(EmbedFooter footer)
+  {
+    return this.Set("footer", view_as<JSON>(footer));
+  }
 
-	/**
-	 * Retrieve the image of the embed.
-	 * 
-	 * @return    Image of the embed.
-	 */
-	public EmbedImage GetImage()
-	{
-		return view_as<EmbedImage>(this.Get("image"));
-	}
+  /**
+   * Retrieve the image of the embed.
+   * 
+   * @return    Image of the embed.
+   */
+  public EmbedImage GetImage()
+  {
+    return view_as<EmbedImage>(this.Get("image"));
+  }
 
-	/**
-	 * Set the image of the embed.
-	 * 
-	 * @param image    Image of the embed.
-	 * @return         True on success. False otherwise.
-	 */
-	public bool SetImage(EmbedImage image)
-	{
-		return this.Set("image", view_as<JSON>(image));
-	}
+  /**
+   * Set the image of the embed.
+   * 
+   * @param image    Image of the embed.
+   * @return         True on success. False otherwise.
+   */
+  public bool SetImage(EmbedImage image)
+  {
+    return this.Set("image", view_as<JSON>(image));
+  }
 
-	/**
-	 * Retrieve the thumbnail of the embed.
-	 * 
-	 * @return    Thumbnail of the embed.
-	 */
-	public EmbedThumbnail GetThumbnail()
-	{
-		return view_as<EmbedThumbnail>(this.Get("thumbnail"));
-	}
+  /**
+   * Retrieve the thumbnail of the embed.
+   * 
+   * @return    Thumbnail of the embed.
+   */
+  public EmbedThumbnail GetThumbnail()
+  {
+    return view_as<EmbedThumbnail>(this.Get("thumbnail"));
+  }
 
-	/**
-	 * Set the thumbnail of the embed.
-	 * 
-	 * @param thumbnail    Thumbnail of the embed.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool SetThumbnail(EmbedThumbnail thumbnail)
-	{
-		return this.Set("thumbnail", view_as<JSON>(thumbnail));
-	}
+  /**
+   * Set the thumbnail of the embed.
+   * 
+   * @param thumbnail    Thumbnail of the embed.
+   * @return             True on success. False otherwise.
+   */
+  public bool SetThumbnail(EmbedThumbnail thumbnail)
+  {
+    return this.Set("thumbnail", view_as<JSON>(thumbnail));
+  }
 
-	/**
-	 * Retrieve the video of the embed.
-	 * 
-	 * @return    Video of the embed.
-	 */
-	public EmbedVideo GetVideo()
-	{
-		return view_as<EmbedVideo>(this.Get("video"));
-	}
+  /**
+   * Retrieve the video of the embed.
+   * 
+   * @return    Video of the embed.
+   */
+  public EmbedVideo GetVideo()
+  {
+    return view_as<EmbedVideo>(this.Get("video"));
+  }
 
-	/**
-	 * Set the video of the embed.
-	 * 
-	 * @param video					Video of the embed.
-	 * @return							True on success. False otherwise.
-	 */
-	public bool SetVideo(EmbedVideo video)
-	{
-		return this.Set("video", view_as<JSON>(video));
-	}
+  /**
+   * Set the video of the embed.
+   * 
+   * @param video					Video of the embed.
+   * @return							True on success. False otherwise.
+   */
+  public bool SetVideo(EmbedVideo video)
+  {
+    return this.Set("video", view_as<JSON>(video));
+  }
 
-	/**
-	 * Retrieve the provider of the embed.
-	 * 
-	 * @return			Provider of the embed.
-	 */
-	public EmbedProvider GetProvider()
-	{
-		return view_as<EmbedProvider>(this.Get("provider"));
-	}
+  /**
+   * Retrieve the provider of the embed.
+   * 
+   * @return			Provider of the embed.
+   */
+  public EmbedProvider GetProvider()
+  {
+    return view_as<EmbedProvider>(this.Get("provider"));
+  }
 
-	/**
-	 * Set the provider of the embed.
-	 * 
-	 * @param provider    Provider of the embed.
-	 * @return            True on success. False otherwise.
-	 */
-	public bool SetProvider(EmbedProvider provider)
-	{
-		return this.Set("provider", view_as<JSON>(provider));
-	}
+  /**
+   * Set the provider of the embed.
+   * 
+   * @param provider    Provider of the embed.
+   * @return            True on success. False otherwise.
+   */
+  public bool SetProvider(EmbedProvider provider)
+  {
+    return this.Set("provider", view_as<JSON>(provider));
+  }
 
-	/**
-	 * Retrieve the author of the embed.
-	 * 
-	 * @return    Author of the embed.
-	 */
-	public EmbedAuthor GetAuthor()
-	{
-		return view_as<EmbedAuthor>(this.Get("author"));
-	}
+  /**
+   * Retrieve the author of the embed.
+   * 
+   * @return    Author of the embed.
+   */
+  public EmbedAuthor GetAuthor()
+  {
+    return view_as<EmbedAuthor>(this.Get("author"));
+  }
 
-	/**
-	 * Set the author of the embed.
-	 * 
-	 * @param author    Author of the embed.
-	 * @return          True on success. False otherwise.
-	 */
-	public bool SetAuthor(EmbedAuthor author)
-	{
-		return this.Set("author", view_as<JSON>(author));
-	}
+  /**
+   * Set the author of the embed.
+   * 
+   * @param author    Author of the embed.
+   * @return          True on success. False otherwise.
+   */
+  public bool SetAuthor(EmbedAuthor author)
+  {
+    return this.Set("author", view_as<JSON>(author));
+  }
 
-	/**
-	 * Retrieve the fields of the embed.
-	 * 
-	 * @return    JSONArray containing the fields of the embed from its index.
-	 */
-	public JSONArray GetFields()
-	{
-		return view_as<JSONArray>(this.Get("fields"));
-	}
+  /**
+   * Retrieve the fields of the embed.
+   * 
+   * @return    JSONArray containing the fields of the embed from its index.
+   */
+  public JSONArray GetFields()
+  {
+    return view_as<JSONArray>(this.Get("fields"));
+  }
 
-	/**
-	 * Retrieve a field of the embed.
-	 * 
-	 * @return    Field corresponding to the input index. null if an error occurs.
-	 */
-	public EmbedField GetField(int index)
-	{
-		JSONArray fields = view_as<JSONArray>(this.Get("fields"));
-		if(fields != null && fields.Length < index)
-		{
-			return view_as<EmbedField>(fields.Get(index));
-		}
-		return null;
-	}
+  /**
+   * Retrieve a field of the embed.
+   * 
+   * @return    Field corresponding to the input index. null if an error occurs.
+   */
+  public EmbedField GetField(int index)
+  {
+    JSONArray fields = view_as<JSONArray>(this.Get("fields"));
+    if(fields != null && fields.Length < index)
+    {
+      return view_as<EmbedField>(fields.Get(index));
+    }
+    return null;
+  }
 
-	/**
-	 * Add a field to the embed. This will delete the field.
-	 * 
-	 * @param field    Field to add to the embed.
-	 * @return         The number of fields after the new one was added. -1 otherwise.
-	 */
-	public int AddField(EmbedField field)
-	{
-		JSONArray fields;
-		if(this.HasKey("fields"))
-		{
-			fields = view_as<JSONArray>(this.Get("fields"));
-		}
-		else
-		{
-			fields = new JSONArray();
-		}
-		if(fields.Push(view_as<JSON>(field)))
-		{
-			if(this.Set("fields", fields))
-			{
-				delete field;
-				return fields.Length;
-			}
-		}
-		return -1;
-	}
+  /**
+   * Add a field to the embed. This will delete the field.
+   * 
+   * @param field    Field to add to the embed.
+   * @return         The number of fields after the new one was added. -1 otherwise.
+   */
+  public int AddField(EmbedField field)
+  {
+    JSONArray fields;
+    if(this.HasKey("fields"))
+    {
+      fields = view_as<JSONArray>(this.Get("fields"));
+    }
+    else
+    {
+      fields = new JSONArray();
+    }
+    if(fields.Push(view_as<JSON>(field)))
+    {
+      if(this.Set("fields", fields))
+      {
+        delete field;
+        return fields.Length;
+      }
+    }
+    return -1;
+  }
 }
 
 
 methodmap Webhook < JSONObject
 {
-	/**
-	 * Constructor for the Embed methodmap.
-	 * 
-	 * @param content    Content of the webhook.
-	 * @return           Returns the Embed.
-	 */
-	public Webhook(const char[] content="") 
-	{
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.SetString("content", content);
-		return view_as<Webhook>(jsonObject);
-	}
+  /**
+   * Constructor for the Embed methodmap.
+   * 
+   * @param content    Content of the webhook.
+   * @return           Returns the Embed.
+   */
+  public Webhook(const char[] content="") 
+  {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.SetString("content", content);
+    return view_as<Webhook>(jsonObject);
+  }
 
-	/**
-	 * Retrieve the content of the webhook.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetContent(char[] buffer, int maxlength)
-	{
-		return this.GetString("content", buffer, maxlength);
-	}
+  /**
+   * Retrieve the content of the webhook.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetContent(char[] buffer, int maxlength)
+  {
+    return this.GetString("content", buffer, maxlength);
+  }
 
-	/**
-	 * Set the content of the webhook.
-	 * 
-	 * @param content    Content of the webhook.
-	 * @return           True on success. False otherwise.
-	 */
-	public bool SetContent(const char[] content)
-	{
-		return this.SetString("content", content);
-	}
+  /**
+   * Set the content of the webhook.
+   * 
+   * @param content    Content of the webhook.
+   * @return           True on success. False otherwise.
+   */
+  public bool SetContent(const char[] content)
+  {
+    return this.SetString("content", content);
+  }
 
-	/**
-	 * Retrieve the username of the webhook.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetUsername(char[] buffer, int maxlength)
-	{
-		return this.GetString("username", buffer, maxlength);
-	}
+  /**
+   * Retrieve the username of the webhook.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetUsername(char[] buffer, int maxlength)
+  {
+    return this.GetString("username", buffer, maxlength);
+  }
 
-	/**
-	 * Set the username of the webhook.
-	 * 
-	 * @param username      Username of the webhook.
-	 * @return              True on success. False otherwise.
-	 */
-	public bool SetUsername(const char[] username)
-	{
-		return this.SetString("username", username);
-	}
+  /**
+   * Set the username of the webhook.
+   * 
+   * @param username      Username of the webhook.
+   * @return              True on success. False otherwise.
+   */
+  public bool SetUsername(const char[] username)
+  {
+    return this.SetString("username", username);
+  }
 
-	/**
-	 * Retrieve the avatar_url of the webhook.
-	 * 
-	 * @param buffer       String buffer to store value.
-	 * @param maxlength    Maximum length of the string buffer.
-	 * @return             True on success. False otherwise.
-	 */
-	public bool GetAvatarURL(char[] buffer, int maxlength)
-	{
-		return this.GetString("avatar_url", buffer, maxlength);
-	}
+  /**
+   * Retrieve the avatar_url of the webhook.
+   * 
+   * @param buffer       String buffer to store value.
+   * @param maxlength    Maximum length of the string buffer.
+   * @return             True on success. False otherwise.
+   */
+  public bool GetAvatarURL(char[] buffer, int maxlength)
+  {
+    return this.GetString("avatar_url", buffer, maxlength);
+  }
 
-	/**
-	 * Set the avatar URL of the webhook.
-	 * 
-	 * @param avatar_url    Avatar URL of the webhook.
-	 * @return              True on success. False otherwise.
-	 */
-	public bool SetAvatarURL(const char[] avatar_url)
-	{
-		return this.SetString("avatar_url", avatar_url);
-	}
+  /**
+   * Set the avatar URL of the webhook.
+   * 
+   * @param avatar_url    Avatar URL of the webhook.
+   * @return              True on success. False otherwise.
+   */
+  public bool SetAvatarURL(const char[] avatar_url)
+  {
+    return this.SetString("avatar_url", avatar_url);
+  }
 
-	/**
-	 * Retrieve the tts @parameter of the webhook.
-	 * 
-	 * @return    Bool representing the tts @parameter of the webhook.
-	 */
-	public bool GetTTS()
-	{
-		return this.GetBool("tts");
-	}
+  /**
+   * Retrieve the tts @parameter of the webhook.
+   * 
+   * @return    Bool representing the tts @parameter of the webhook.
+   */
+  public bool GetTTS()
+  {
+    return this.GetBool("tts");
+  }
 
-	/**
-	 * Set the tts @parameter of the webhook.
-	 * 
-	 * @param tts    TTS @parameter of the webhook.
-	 * @return       True on success. False otherwise.
-	 */
-	public bool SetTTS(bool tts)
-	{
-		return this.SetBool("tts", tts);
-	}
+  /**
+   * Set the tts @parameter of the webhook.
+   * 
+   * @param tts    TTS @parameter of the webhook.
+   * @return       True on success. False otherwise.
+   */
+  public bool SetTTS(bool tts)
+  {
+    return this.SetBool("tts", tts);
+  }
 
-	/**
-	 * Retrieve the embeds of the webhook.
-	 * 
-	 * @return    JSONArray containing the embeds of the webhook.
-	 */
-	public JSONArray GetEmbeds()
-	{
-		return view_as<JSONArray>(this.Get("embeds"));
-	}
+  /**
+   * Retrieve the embeds of the webhook.
+   * 
+   * @return    JSONArray containing the embeds of the webhook.
+   */
+  public JSONArray GetEmbeds()
+  {
+    return view_as<JSONArray>(this.Get("embeds"));
+  }
 
-	/**
-	 * Retrieve an embed of the webook from its index.
-	 * 
-	 * @return    Embed corresponding to the input index. null if an error occurs.
-	 */
-	public Embed GetEmbed(int index)
-	{
-		JSONArray embeds = view_as<JSONArray>(this.Get("embeds"));
-		if(embeds != null && embeds.Length < index)
-		{
-			return view_as<Embed>(embeds.Get(index));
-		}
-		return null;
-	}
+  /**
+   * Retrieve an embed of the webook from its index.
+   * 
+   * @return    Embed corresponding to the input index. null if an error occurs.
+   */
+  public Embed GetEmbed(int index)
+  {
+    JSONArray embeds = view_as<JSONArray>(this.Get("embeds"));
+    if(embeds != null && embeds.Length < index)
+    {
+      return view_as<Embed>(embeds.Get(index));
+    }
+    return null;
+  }
 
-	/**
-	 * Add an embed to the webhook. This will delete the handle to the embed.
-	 * 
-	 * @param embed    Embed to add to the webhook.
-	 * @return         The number of embeds after the new one was added. -1 otherwise.
-	 */
-	public int AddEmbed(Embed embed)
-	{
-		JSONArray embeds;
-		if(this.HasKey("embeds"))
-		{
-			embeds = view_as<JSONArray>(this.Get("embeds"));
-		}
-		else
-		{
-			embeds = new JSONArray();
-		}
-		if(embeds.Push(view_as<JSON>(embed)))
-		{
-			if(this.Set("embeds", embeds))
-			{
-				delete embed;
-				return embeds.Length;
-			}
-		}
-		return -1;
-	}
+  /**
+   * Add an embed to the webhook. This will delete the handle to the embed.
+   * 
+   * @param embed    Embed to add to the webhook.
+   * @return         The number of embeds after the new one was added. -1 otherwise.
+   */
+  public int AddEmbed(Embed embed)
+  {
+    JSONArray embeds;
+    if(this.HasKey("embeds"))
+    {
+      embeds = view_as<JSONArray>(this.Get("embeds"));
+    }
+    else
+    {
+      embeds = new JSONArray();
+    }
+    if(embeds.Push(view_as<JSON>(embed)))
+    {
+      if(this.Set("embeds", embeds))
+      {
+        delete embed;
+        return embeds.Length;
+      }
+    }
+    return -1;
+  }
 
-	/**
-	 * Execute the webhook.
-	 * 
-	 * @param webhook       URL of the webhook. MAKE SURE THERE IS NO TRAILING `/`.
-	 * @param callback      Callback function called when the HTTP request has been processed.
-	 * @param data          Optional value to pass to the callback function.
-	 */
-	public void Execute(const char[] webhook, HTTPRequestCallback callback, any data = 0)
-	{
-		char webhook_wait[1024];
-		Format(webhook_wait, sizeof webhook_wait, "%s?wait=true", webhook);
-		HTTPRequest httpRequest = new HTTPRequest(webhook_wait);
-		#if defined DEBUG
-			char debug[9999];
-			this.toString(debug, sizeof debug);
-			PrintToServer(debug);
-		#endif
-		httpRequest.Post(view_as<JSON>(this), callback, data);
-		delete httpRequest;
-		return;
-	}
+  /**
+   * Execute the webhook.
+   * 
+   * @param webhook       URL of the webhook. MAKE SURE THERE IS NO TRAILING `/`.
+   * @param callback      Callback function called when the HTTP request has been processed.
+   * @param data          Optional value to pass to the callback function.
+   */
+  public void Execute(const char[] webhook, HTTPRequestCallback callback, any data = 0)
+  {
+    char webhook_wait[1024];
+    Format(webhook_wait, sizeof webhook_wait, "%s?wait=true", webhook);
+    HTTPRequest httpRequest = new HTTPRequest(webhook_wait);
+    #if defined DEBUG
+      char debug[9999];
+      this.toString(debug, sizeof debug);
+      PrintToServer(debug);
+    #endif
+    httpRequest.Post(view_as<JSON>(this), callback, data);
+  }
 
-	/**
-	 * Edit a previously sent webhook, knowing its messageId.
-	 * 
-	 * @param webhook      URL of the webhook.
-	 * @param messageId    ID of the message to edit.
-	 * @param callback     Callback function called when the HTTP request has been processed.
-	 * @param data         Optional value to pass to the callback function.
-	 */
-	public void Edit(const char[] webhook, const char[] messageId, HTTPRequestCallback callback, any data = 0)
-	{
-		char webhook_patch[1024];
-		Format(webhook_patch, sizeof webhook_patch, "%s/messages/%s", webhook, messageId);
-		HTTPRequest httpRequest = new HTTPRequest(webhook_patch);
-		httpRequest.Patch(view_as<JSON>(this), callback, data);
-		delete httpRequest;
-		return;
-	}
+  /**
+   * Edit a previously sent webhook, knowing its messageId.
+   * 
+   * @param webhook      URL of the webhook.
+   * @param messageId    ID of the message to edit.
+   * @param callback     Callback function called when the HTTP request has been processed.
+   * @param data         Optional value to pass to the callback function.
+   */
+  public void Edit(const char[] webhook, const char[] messageId, HTTPRequestCallback callback, any data = 0)
+  {
+    char webhook_patch[1024];
+    Format(webhook_patch, sizeof webhook_patch, "%s/messages/%s", webhook, messageId);
+    HTTPRequest httpRequest = new HTTPRequest(webhook_patch);
+    httpRequest.Patch(view_as<JSON>(this), callback, data);
+  }
 }

--- a/scripting/include/surftimer.inc
+++ b/scripting/include/surftimer.inc
@@ -101,11 +101,34 @@ native void surftimer_GetPlayerNameColored(int client, char[] str);
 /**
  * Retrieves the current map's WR holder and the associated time.
  *
- * @param name				String to store the WR holder's name.
- * @param time				String to store the WR holder's time.
+ * @param szname				String to store the WR holder's name.
+ * @param sztime				String to store the WR holder's time.
+ * @param time					float to store the WR holder's time.
  * @return						The number of players who have finished the current map.
  */
-native int surftimer_GetMapData(char[] name, char[] time);
+native int surftimer_GetMapData(char[] szname, char[] sztime, float& time);
+
+/**
+ * Retrieves the wr/pb info regarding the current bonus a players is on
+ *
+ * @param client				The client's ID.
+ * @param szWRname				String to store the Bonus WR holder's name.
+ * @param WRtime				float to store the Bonus WR holder's time.
+ * @param pbtime				float to store the Bonus PB holder's time.
+ * @return						The number of players who have finished the current bonus.
+ */
+native int surftimer_GetBonusData(int client, char[] szWRname, float& WRtime, float& PBtime);
+
+/**
+ * Retrieves the current map's stage WR holder and the associated times.
+ *
+ * @param client				The client's ID.
+ * @param szWRname				String to store the stage WR holder's name.
+ * @param WRtime				float to store the stage WR holder's time.
+ * @param pbtime				float to store the stage PB holder's time.
+ * @return						The number of players who have finished the current stage.
+ */
+native int surftimer_GetStageData(int client, char[] szWRname, float& WRtime, float& PBtime);
 
 /**
  * Retrieves the client's data.
@@ -117,7 +140,7 @@ native int surftimer_GetMapData(char[] name, char[] time);
  * @param countryCode			String to store the client's countryCode.
  * @param continentCode			String to store the client's continentCode.
  */
-native void surftimer_GetPlayerData(int& client, char[] time, int& rank, char[] country, char countryCode[3], char continentCode[3]);
+native void surftimer_GetPlayerData(int& client, float& time, int& rank, char[] country, char countryCode[3], char continentCode[3]);
 
 /**
  * Retrieves the client's current info.
@@ -129,6 +152,22 @@ native void surftimer_GetPlayerData(int& client, char[] time, int& rank, char[] 
  * @param iBonus			Int to store the client's current bonus.
  */
 native void surftimer_GetPlayerInfo(int& client, int& iWrcpTimer, int& iPracMode, int& iStage, int& iBonus);
+
+/**
+ * Retrieves the client's current sync.
+ *
+ * @param client			The client's ID.
+ * @return					Client's sync.
+ */
+native float surftimer_GetClientSync(int client);
+
+/**
+ * Retrieves the client's current style.
+ *
+ * @param client			The client's ID.
+ * @return					Current client's style.
+ */
+native int surftimer_GetClientStyle(int client);
 
 /**
  * Teleport a client safely, without triggering end touches
@@ -151,15 +190,22 @@ native bool surftimer_SafeTeleport(int client, float fDestination[3], float fAng
  * @param client			The client's ID.
  * @return						Plugin_Handled, to stop the client from searching.
  */
-forward Action surftimer_OnMapFinished(int client, float fRunTime, char sRunTime[54], int rank, int total, int style);
+forward Action surftimer_OnMapFinished(int client, float fRunTime, char sRunTime[54], float PBDiff, float WRDiff, int rank, int total, int style, ArrayList cps);
 
 /**
  * Called when a player reaches a checkpoint zone or a stage.
  *
  * @param client			The client's ID.
- * @return						Plugin_Handled, to stop the client from searching.
+ * @param fRunTime			Run time of the client to the checkpoint in float
+ * @param sRunTime			Run time of the client to the checkpoint
+ * @param fPbCp				Personal best of the client to the checkpoint in float
+ * @param sPbDiff			Personal best difference of the client with current run time
+ * @param fSrCp				Record checkpoint time in float
+ * @param sSrDiff			Record checkpoint time difference of the client with current run time
+ * @param iCheckpoint		Checkpoint number that was just passed
+ * @return					Plugin_Handled, to stop the client from searching.
  */
-forward Action surftimer_OnCheckpoint(int client, float fRunTime, char sRunTime[54], float fPbCp, char sPbDiff[16], char fSrCp, char sSrDiff[16]);
+forward Action surftimer_OnCheckpoint(int client, float fRunTime, char sRunTime[54], float fPbCp, char sPbDiff[16], float fSrCp, char sSrDiff[16], int iCheckpoint);
 
 
 /**
@@ -168,7 +214,7 @@ forward Action surftimer_OnCheckpoint(int client, float fRunTime, char sRunTime[
  * @param client			The client's ID.
  * @return						Plugin_Handled, to stop the player from searching.
  */
-forward Action surftimer_OnBonusFinished(int client, float fRunTime, char sRunTime[54], int rank, int total, int bonusid);
+forward Action surftimer_OnBonusFinished(int client, float fRunTime, char sRunTime[54], float fPBDiff, float fSRDiff, int rank, int total, int bonusid, int style);
 
 /**
  * Called when a client finishes a map in practice mode
@@ -185,9 +231,10 @@ forward Action surftimer_OnPracticeFinished(int client, float fRunTime, char sRu
  * @param style				Style index.
  * @param time				Time set by the player.
  * @param timeDif			Time difference with the former record.
- * @param bonusGroup	Group of the bonus. -1 if the record isn't a bonus.
+ * @param bonusGroup	    Group of the bonus. -1 if the record isn't a bonus.
+ * @param checkpoints       Array with checkpoint differences for the run.
  */
-forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup);
+forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup, ArrayList checkpoints);
 
 /**
  * Called when a client sets a new WRCP
@@ -200,6 +247,27 @@ forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] ti
  * @param fRunTime			Run time for the WRCP in float.
  */
 forward void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime);
+
+/**
+ * Called when a client sets a new WRCP
+ *
+ * @param client			The client's ID.
+ * @param style				Style index.
+ * @param time				Time set by the player.
+ * @param timeDif			Time difference with the former record.
+ * @param stage			  	The id of the stage of the WRCP.
+ * @param fRunTime			Run time for the WRCP in float.
+ * @param fClientRunTime	Run time for the client of the current stage in float.
+ */
+forward void surftimer_OnStageFinished(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime, float fClientRunTime);
+
+/**
+ * Converts steamid2 (STEAM_X:Y:Z) to the accountid which will returned.
+ */
+stock int SteamId2ToAccountId(const char[] steamid)
+{
+    return (StringToInt(steamid[10]) * 2) + (steamid[8] == '1' ? 1 : 0);
+}
 
 public SharedPlugin:__pl_surftimer =
 {
@@ -223,4 +291,5 @@ public __pl_surftimer_SetNTVOptional()
 	MarkNativeAsOptional("surftimer_GetServerRank");
 	MarkNativeAsOptional("surftimer_SafeTeleport");
 	MarkNativeAsOptional("surftimer_OnNewRecord");
+	MarkNativeAsOptional("surftimer_OnStageFinished");
 }

--- a/scripting/include/surftimer.inc
+++ b/scripting/include/surftimer.inc
@@ -185,6 +185,41 @@ native bool surftimer_SafeTeleport(int client, float fDestination[3], float fAng
 /*  FORWARDS  */
 
 /**
+ * Called when a client map timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ */
+forward void surftimer_OnClientTimerStart(int client, int style);
+
+/**
+ * Called when a client WRCP timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ * @param stage 		   Stage number the client is currently running.
+ */
+forward void surftimer_OnClientWRCPTimerStart(int client, int style, int stage);
+
+/**
+ * Called when a client Bonus timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ * @param bonus 		   Bonus number the client is currently running.
+ */
+forward void surftimer_OnClientBonusTimerStart(int client, int style, int bonus);
+
+/**
+ * Called when a client enters Practice mode
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ * @param locNum 		   Number of the saveloc the client teleported to.
+ */
+forward void surftimer_OnClientPracTimerStart(int client, int style, int locNum);
+
+/**
  * Called when a client finishes a map.
  *
  * @param client			The client's ID.
@@ -234,7 +269,7 @@ forward Action surftimer_OnPracticeFinished(int client, float fRunTime, char sRu
  * @param bonusGroup	    Group of the bonus. -1 if the record isn't a bonus.
  * @param checkpoints       Array with checkpoint differences for the run.
  */
-forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup, ArrayList checkpoints);
+forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] timeDif, int bonusGroup, ArrayList cps);
 
 /**
  * Called when a client sets a new WRCP


### PR DESCRIPTION
Add the checkpoints data for the run in the embed like so:
![image](https://github.com/surftimer/SurfTimer-discord/assets/74899888/0e95b531-7cd4-44b7-a85a-35c49fb77378)


 - There is a character limitation from [Discord](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure) side for embed fields, so I tried limiting the amount of characters that can be present for adding that field. 
 - Also updated **discordWebhookAPI** include with newest version, ty @Sarrus1 
 - Updated **surftimer** include as well
 - Added some more prints in case of an error with `DEBUG` on (for rate limitation)


## This will most likely NOT work for maps with more than 28ish stages/checkpoints
_looks at *surf_classics*_ 👀 



# To be merged when a release of SurfTimer with this [PR](https://github.com/surftimer/SurfTimer/pull/591) is made